### PR TITLE
support canvas scaling for custom div widths

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -18,6 +18,7 @@
         "connect-snake": "file:../connect-snake-0.1.0.tgz",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.7.4",
         "web-vitals": "^2.1.4"
@@ -5103,7 +5104,7 @@
     "node_modules/connect-snake": {
       "version": "0.1.0",
       "resolved": "file:../connect-snake-0.1.0.tgz",
-      "integrity": "sha512-ZVzN77ok9/Wngk9YngOncz1KwvBSoc7ZCsKQPfzVVg4gITPMmemCLbn6xSZ5bRiUs0ve/Vogp+fxEqfFiVi1Gw==",
+      "integrity": "sha512-7Zp3zKVF08Y6pBBoq1jOfGv14wGFLHFrg1Isq06xGdQPY2UPeBhoLcrb7VzTlV3cAIQwJzRGEQE2510z2uZjCQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.2.0",
@@ -6013,9 +6014,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.200",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.200.tgz",
-      "integrity": "sha512-nPyI7oHc8T64oSqRXrAt99gNMpk0SAgPHw/o+hkNKyb5+bcdnFtZcSO9FUJES5cVkVZvo8u4qiZ1gQILl8UXsA=="
+      "version": "1.4.202",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.202.tgz",
+      "integrity": "sha512-JYsK2ex9lmQD27kj19fhXYxzFJ/phLAkLKHv49A5UY6kMRV2xED3qMMLg/voW/+0AR6wMiI+VxlmK9NDtdxlPA=="
     },
     "node_modules/email-addresses": {
       "version": "3.1.0",
@@ -7817,6 +7818,14 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/hoopy": {
@@ -12166,6 +12175,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "dependencies": {
+        "history": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "dependencies": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -12615,9 +12648,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.0.tgz",
-      "integrity": "sha512-vL8xjY4yOQEw79DvyXLijhnhh+R/O9zpF/LEgkCebZFtb6ELeN9H3/2T0r8+mp+fFTBHZ5qGpOpW2ela2zRt3g==",
+      "version": "2.77.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.1.tgz",
+      "integrity": "sha512-GhutNJrvTYD6s1moo+kyq7lD9DeR5HDyXo4bDFlDSkepC9kVKY+KK/NSZFzCmeXeia3kEzVuToQmHRdugyZHxw==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -18613,7 +18646,7 @@
     },
     "connect-snake": {
       "version": "file:../connect-snake-0.1.0.tgz",
-      "integrity": "sha512-ZVzN77ok9/Wngk9YngOncz1KwvBSoc7ZCsKQPfzVVg4gITPMmemCLbn6xSZ5bRiUs0ve/Vogp+fxEqfFiVi1Gw==",
+      "integrity": "sha512-7Zp3zKVF08Y6pBBoq1jOfGv14wGFLHFrg1Isq06xGdQPY2UPeBhoLcrb7VzTlV3cAIQwJzRGEQE2510z2uZjCQ==",
       "requires": {}
     },
     "content-disposition": {
@@ -19249,9 +19282,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.200",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.200.tgz",
-      "integrity": "sha512-nPyI7oHc8T64oSqRXrAt99gNMpk0SAgPHw/o+hkNKyb5+bcdnFtZcSO9FUJES5cVkVZvo8u4qiZ1gQILl8UXsA=="
+      "version": "1.4.202",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.202.tgz",
+      "integrity": "sha512-JYsK2ex9lmQD27kj19fhXYxzFJ/phLAkLKHv49A5UY6kMRV2xED3qMMLg/voW/+0AR6wMiI+VxlmK9NDtdxlPA=="
     },
     "email-addresses": {
       "version": "3.1.0",
@@ -20559,6 +20592,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
     },
     "hoopy": {
       "version": "0.1.4",
@@ -23545,6 +23586,23 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
+    "react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      }
+    },
     "react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -23873,9 +23931,9 @@
       }
     },
     "rollup": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.0.tgz",
-      "integrity": "sha512-vL8xjY4yOQEw79DvyXLijhnhh+R/O9zpF/LEgkCebZFtb6ELeN9H3/2T0r8+mp+fFTBHZ5qGpOpW2ela2zRt3g==",
+      "version": "2.77.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.1.tgz",
+      "integrity": "sha512-GhutNJrvTYD6s1moo+kyq7lD9DeR5HDyXo4bDFlDSkepC9kVKY+KK/NSZFzCmeXeia3kEzVuToQmHRdugyZHxw==",
       "requires": {
         "fsevents": "~2.3.2"
       }

--- a/example/package.json
+++ b/example/package.json
@@ -14,6 +14,7 @@
     "connect-snake": "file:../connect-snake-0.1.0.tgz",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.7.4",
     "web-vitals": "^2.1.4"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { ReactConnectSnake } from 'connect-snake';
 
 function App() {
-  return <ReactConnectSnake tabIndex={0} />;
+  const [searchParams, ] = useSearchParams();
+
+  const widthParam = searchParams.get('width')
+  const width = widthParam !== null ? parseInt(widthParam) : undefined
+
+  return <ReactConnectSnake width={width} tabIndex={0} />;
 }
 
 export default App;

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
 const root = ReactDOM.createRoot(
@@ -7,7 +8,9 @@ const root = ReactDOM.createRoot(
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );
 

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ Build the package first, then install the dependencies in the example:
 npm build
 npm pack
 cd example
+rm -rf node_modules
 npm install
 npm start
 ```

--- a/src/components/ReactConnectBoard/ConnectBoard.stories.tsx
+++ b/src/components/ReactConnectBoard/ConnectBoard.stories.tsx
@@ -31,6 +31,18 @@ interface ManualTestComponentProps {
     holes: HolePosition[],
 }
 
+export const ScaledDownConnectBoard = BasicTemplate.bind({})
+ScaledDownConnectBoard.args = {
+  width: 500,
+  onLoad: () => {},
+}
+
+export const ScaledUpConnectBoard = BasicTemplate.bind({})
+ScaledUpConnectBoard.args = {
+  width: 900,
+  onLoad: () => {},
+}
+
 const ManualTestComponent: React.FC<ManualTestComponentProps> = (props: ManualTestComponentProps) => {
   const [renderer, setRenderer] = useState<ConnectBoardRenderer | null>(null);
 
@@ -62,7 +74,8 @@ ManualTestConnectBoard.args = {
 };
 
 interface LoopTestComponentProps {
-    intervalMs: number,
+  width: number,
+  intervalMs: number,
 }
 
 const LoopTestComponent: React.FC<LoopTestComponentProps> = (props: LoopTestComponentProps) => {
@@ -96,12 +109,18 @@ const LoopTestComponent: React.FC<LoopTestComponentProps> = (props: LoopTestComp
     setTimeout(onIteration, props.intervalMs);
   }, [props, renderer, position]);
 
-  return <ReactConnectBoard onLoad={setRenderer} />;
+  return <ReactConnectBoard onLoad={setRenderer} width={props.width} />;
 };
 
 const LoopTestTemplate: ComponentStory<typeof LoopTestComponent> = (args: LoopTestComponentProps) => <LoopTestComponent {...args} />;
 
 export const TestHolePropsTemplate = LoopTestTemplate.bind({});
 TestHolePropsTemplate.args = {
+  intervalMs: 200,
+};
+
+export const ScaledTestHolePropsTemplate = LoopTestTemplate.bind({});
+ScaledTestHolePropsTemplate.args = {
+  width: 500,
   intervalMs: 200,
 };

--- a/src/components/ReactConnectSnake.stories.tsx
+++ b/src/components/ReactConnectSnake.stories.tsx
@@ -1,12 +1,28 @@
 import { ComponentStory } from '@storybook/react';
 import React from 'react';
-import { ReactConnectSnake } from './ReactConnectSnake';
+import { ReactConnectSnake, ReactConnectSnakeProps } from './ReactConnectSnake';
 
 export default {
   title: 'Connect Components/ReactConnectSnake',
   component: ReactConnectSnake,
 };
 
-const BasicTemplate: ComponentStory<typeof ReactConnectSnake> = () => (<ReactConnectSnake />);
+const DefaultTemplate: ComponentStory<typeof ReactConnectSnake> = () => (<ReactConnectSnake tabIndex={0} />);
 
-export const DefaultConnectSnake = BasicTemplate.bind({});
+export const DefaultConnectSnake = DefaultTemplate.bind({});
+
+
+type ScaledTemplateArgs = Partial<ReactConnectSnakeProps>
+
+const ScaledTemplate: ComponentStory<typeof ReactConnectSnake> =
+  (args: ScaledTemplateArgs) => (<ReactConnectSnake width={args.width} tabIndex={0} />);
+
+export const ScaledDownConnectSnake = ScaledTemplate.bind({});
+ScaledDownConnectSnake.args = {
+  width: 500,
+}
+
+export const ScaledUpConnectSnake = ScaledTemplate.bind({});
+ScaledUpConnectSnake.args = {
+  width: 1000,
+}

--- a/src/components/ReactConnectSnake.tsx
+++ b/src/components/ReactConnectSnake.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { ConnectBoardRenderer } from '../ConnectBoardDriver';
 import { Snake, PlayerInput, SnakeControllerInput } from '../games';
-import { ReactConnectBoard } from './ReactConnectBoard/ConnectBoard';
+import { ReactConnectBoard, ReactConnectBoardProps } from './ReactConnectBoard/ConnectBoard';
 
 class SnakeKeyboardController implements PlayerInput<SnakeControllerInput> {
   input: SnakeControllerInput | null;
@@ -68,7 +68,9 @@ class SnakeKeyboardController implements PlayerInput<SnakeControllerInput> {
 
 const FPS = 60;
 
-export const ReactConnectSnake: React.FC<React.HTMLAttributes<HTMLElement>> = (props: React.HTMLAttributes<HTMLElement>) => {
+export interface ReactConnectSnakeProps extends Partial<ReactConnectBoardProps> {}
+
+export const ReactConnectSnake: React.FC<ReactConnectSnakeProps> = (props: ReactConnectSnakeProps) => {
   const [game] = useState<Snake>(new Snake());
   const [controller, setController] = useState<SnakeKeyboardController | null>(null);
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,4 +5,5 @@ export {
 
 export {
   ReactConnectSnake,
+  ReactConnectSnakeProps,
 } from './ReactConnectSnake';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export {
   ReactConnectBoard,
   ReactConnectBoardProps,
   ReactConnectSnake,
+  ReactConnectSnakeProps,
 } from './components';
 
 export {


### PR DESCRIPTION
The canvas can now be scaled, so the component can be rendered with a specified width. This is admittedly a self serving feature for my blog, but still seems useful.

The example github pages site has this feature abstracted up to a query parameter, so you can visit https://brahmlower.github.io/connect-snake?width=500 to play with the component scaled to 500 pixels wide rather than the default 720 pixels.