### PR TITLE
Fixed onLoad callback running too early

### DIFF
--- a/src/components/ReactConnectBoard/Image.tsx
+++ b/src/components/ReactConnectBoard/Image.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { SimpleSpread } from './common';
 
 interface CustomImageProps {
@@ -11,15 +11,17 @@ type ImageProps = SimpleSpread<React.HTMLAttributes<HTMLImageElement>, CustomIma
 const Image: React.FC<ImageProps> = (props: ImageProps) => {
   const { onLoad, ...elemProps } = props;
   const ref = React.useRef<HTMLImageElement>(null);
+  const [imgLoaded, setImgLoaded] = useState<boolean>(false);
 
   useEffect(() => {
-    if (ref.current === null) {
+    if (ref.current === null || imgLoaded === false) {
       return;
     }
-    onLoad(ref.current);
-  });
 
-  return <img ref={ref} {...elemProps} />;
+    onLoad(ref.current);
+  }, [ref, imgLoaded]);
+
+  return <img onLoad={() => setImgLoaded(true)} ref={ref} {...elemProps} />;
 };
 
 export default Image;


### PR DESCRIPTION
This fixes issue #20. Updated the Image component to call the onLoad callback after both the element ref AND the image itself have been loaded. Easy mode 💪 